### PR TITLE
Fixing infinite loop issue in reionization code

### DIFF
--- a/molvs/charge.py
+++ b/molvs/charge.py
@@ -197,6 +197,7 @@ class Reionizer(object):
                 patom.UpdatePropertyCache()
                 charge_diff -= 1
 
+        already_moved = set()
         while True:
             ppos, poccur = self._strongest_protonated(mol)
             ipos, ioccur = self._weakest_ionized(mol)
@@ -205,6 +206,13 @@ class Reionizer(object):
                     # Bad! H wouldn't be moved, resulting in infinite loop.
                     log.warn('Aborted reionization due to unexpected situation')
                     break
+
+                key = tuple(sorted([poccur[-1], ioccur[-1]]))
+                if key in already_moved:
+                    log.warn('Aborting reionization to avoid infinite loop due to it being ambiguous where to put a Hydrogen')
+                    break
+                already_moved.add(key)
+
                 log.info('Moved proton from %s to %s', self.acid_base_pairs[ppos].name, self.acid_base_pairs[ipos].name)
 
                 # Remove hydrogen from strongest protonated

--- a/tests/test_standardize.py
+++ b/tests/test_standardize.py
@@ -13,8 +13,9 @@ from molvs.standardize import standardize_smiles
 logging.basicConfig(level=logging.DEBUG)
 
 def test_should_complete():
-    """Reionization should not infinitely loop forever on this molecule."""
+    """Reionization should not infinitely loop forever on these molecules."""
     assert standardize_smiles('CCCCCCCCCCCCCCCCCC(=O)CC(=C)C(=O)O[Ti](=O)(OC(C)C)C(C)C') == 'C=C(CC(=O)[CH-]CCCCCCCCCCCCCCCC)C(=O)[O-].CC(C)[O-].CCC.[O-2].[Ti+5]'
+    assert standardize_smiles('OP(=O)(O)[O-].OP(=O)([O-])[O-].[O-]S(=O)(=O)[O-].[Na+].[Na+].[Na+].[Mg+2].[Cl-].[Cl-].[K+].[K+]') == 'O=P([O-])(O)O.O=P([O-])([O-])O.O=S(=O)([O-])[O-].[Cl-].[Cl-].[K+].[K+].[Mg+2].[Na+].[Na+].[Na+]'
 
 def test_aromaticity():
     """Check aromaticity is correctly perceived."""

--- a/tests/test_standardize.py
+++ b/tests/test_standardize.py
@@ -12,6 +12,9 @@ from molvs.standardize import standardize_smiles
 
 logging.basicConfig(level=logging.DEBUG)
 
+def test_should_complete():
+    """Reionization should not infinitely loop forever on this molecule."""
+    assert standardize_smiles('CCCCCCCCCCCCCCCCCC(=O)CC(=C)C(=O)O[Ti](=O)(OC(C)C)C(C)C') == 'C=C(CC(=O)[CH-]CCCCCCCCCCCCCCCC)C(=O)[O-].CC(C)[O-].CCC.[O-2].[Ti+5]'
 
 def test_aromaticity():
     """Check aromaticity is correctly perceived."""


### PR DESCRIPTION
This fixes the issue of the reionization code entering an infinite loop as first reported here:
https://github.com/mcs07/MolVS/issues/14

The fix prevents a proton from migrating between the same two atoms twice. If such a case is detected it assumes an infinite loop will be encountered and terminates the loop with a warning.